### PR TITLE
fix: guard protected route from missing email

### DIFF
--- a/src/utils/ProtectedRoute.jsx
+++ b/src/utils/ProtectedRoute.jsx
@@ -9,7 +9,7 @@ const ProtectedRoute = ({ children }) => {
     return <div className="text-center mt-5">⏳ Chargement...</div>;
   }
 
-  if (!user || !user.email.endsWith('@wave.com')) {
+  if (!user || !user.email?.endsWith('@wave.com')) {
     return <Navigate to="/login" />;
   }
 

--- a/src/utils/__tests__/ProtectedRoute.test.jsx
+++ b/src/utils/__tests__/ProtectedRoute.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+// Mock react-router-dom's Navigate component
+jest.mock('react-router-dom', () => ({
+  Navigate: ({ to }) => <div>navigate:{to}</div>,
+}), { virtual: true });
+
+// Mock useAuth to control authentication state
+jest.mock('../authContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+import ProtectedRoute from '../ProtectedRoute';
+import { useAuth } from '../authContext';
+
+describe('ProtectedRoute', () => {
+  it('redirects to login when user email is missing', () => {
+    useAuth.mockReturnValue({ user: {}, authLoading: false });
+
+    render(
+      <ProtectedRoute>
+        <div>secret</div>
+      </ProtectedRoute>
+    );
+
+    expect(screen.queryByText('secret')).toBeNull();
+    expect(screen.getByText('navigate:/login')).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- prevent `ProtectedRoute` from crashing when `user.email` is undefined
- add tests to ensure missing email causes redirect

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a07f65aa8c8321b6b82b2de25c6073